### PR TITLE
Add support for Dockerfiles with directives

### DIFF
--- a/dockerfile.go
+++ b/dockerfile.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
@@ -13,12 +15,23 @@ type dockerfileApplier struct {
 }
 
 func (g *dockerfileApplier) CheckHeader(target *os.File, t *TagContext) (bool, error) {
+	dFlag, dBuf, err := g.checkParserDirectives(target)
+	if err != nil {
+		return false, err
+	}
+	target.Seek(0, 0)
+
 	tbuf, err := ioutil.ReadFile(filepath.Join(t.templatePath, "dockerfile.txt"))
 	if err != nil {
 		return false, err
 	}
 
-	templateBuf := string(tbuf)
+	var templateBuf string
+	if dFlag {
+		templateBuf = fmt.Sprintf("%s%s%s", dBuf, "\n\n", tbuf)
+	} else {
+		templateBuf = string(tbuf)
+	}
 
 	targetBuf := make([]byte, len(templateBuf))
 
@@ -28,10 +41,11 @@ func (g *dockerfileApplier) CheckHeader(target *os.File, t *TagContext) (bool, e
 	}
 
 	if n == len(templateBuf) {
-		if strings.Compare(string(templateBuf), string(targetBuf)) == 0 {
+		if strings.Compare(templateBuf, string(targetBuf)) == 0 {
 			return true, nil
 		}
 	}
+
 	return false, nil
 }
 
@@ -53,8 +67,14 @@ func (g *dockerfileApplier) ApplyHeader(path string, t *TagContext) error {
 		return nil
 	}
 
-	//Reset the read pointers to begining of file.
-	t.templateFiles.dTemplateFile.Seek(0, 0)
+	// Reset the read pointers to begining of file.
+	t.templateFiles.goTemplateFile.Seek(0, 0)
+	file.Seek(0, 0)
+
+	dFlag, dBuf, err := g.checkParserDirectives(file)
+	if err != nil {
+		return err
+	}
 	file.Seek(0, 0)
 
 	tempFile := path + ".tmp"
@@ -65,6 +85,11 @@ func (g *dockerfileApplier) ApplyHeader(path string, t *TagContext) error {
 	defer tFile.Close()
 
 	reader := bufio.NewReader(file)
+	if dFlag {
+		tFile.Write(dBuf)
+		tFile.Write([]byte("\n\n"))
+		_, err = reader.Discard(len(dBuf))
+	}
 
 	t.templateFiles.dTemplateFile.Seek(0, 0)
 	_, err = io.Copy(tFile, t.templateFiles.dTemplateFile)
@@ -82,4 +107,51 @@ func (g *dockerfileApplier) ApplyHeader(path string, t *TagContext) error {
 		return err
 	}
 	return nil
+}
+
+var parserDirective = regexp.MustCompile(`^#\s*\w+=.*`)
+
+// checkParserDirectives captures Dockerfile parser directives.
+//
+// Parser directives are optional, and affect the way in which subsequent lines
+// in a Dockerfile are handled. Parser directives are written as a special type
+// of comment in the form # directive=value. A single directive may only be used
+// once.
+//
+// Once a comment, empty line or builder instruction has been processed, Docker
+// no longer looks for parser directives. Instead it treats anything formatted
+// as a parser directive as a comment and does not attempt to validate if it
+// might be a parser directive. Therefore, all parser directives must be at the
+// very top of a Dockerfile.
+//
+// Parser directives are not case-sensitive. However, convention is for them to
+// be lowercase. Convention is also to include a blank line following any parser
+// directives. Line continuation characters are not supported in parser directives.
+func (g *dockerfileApplier) checkParserDirectives(target *os.File) (bool, []byte, error) {
+	reader := bufio.NewReader(target)
+	line, err := reader.ReadBytes('\n')
+	if err != nil {
+		return false, nil, err
+	}
+
+	if !parserDirective.Match(line) {
+		return false, nil, nil
+	}
+	buf := append([]byte{}, line...)
+
+	for {
+		line, err = reader.ReadBytes('\n')
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return false, nil, err
+		}
+		if !parserDirective.Match(line) {
+			// found a non-directive: stop looking for more directives,
+			// and return those that were found
+			return true, buf, nil
+		}
+		buf = append(buf, line...)
+	}
+	return true, buf, nil
 }

--- a/dockerfile_test.go
+++ b/dockerfile_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDockerfileApplier_ApplyHeader(t *testing.T){
+	tc := newTagContext(t)
+	defer func() { _ = tc.templateFiles.dTemplateFile.Close()}()
+
+
+	tmpDir, err := ioutil.TempDir("", t.Name())
+	if err != nil {
+		t.Fatalf("failed to create temp directory")
+	}
+	defer func() { _ = os.RemoveAll(tmpDir)}()
+
+	files := []string{
+		"Dockerfile.nodirectives",
+		"Dockerfile.comments",
+		"Dockerfile.single-directive",
+		"Dockerfile.multiple-directives",
+	}
+
+	d := dockerfileApplier{}
+	for _, f := range files {
+		fileName := f
+		t.Run(fileName, func(t *testing.T){
+			testfile := filepath.Join(tmpDir, fileName)
+			copyFile(t, "./testdata/"+fileName, testfile)
+
+			err = d.ApplyHeader(testfile, &tc)
+			if err != nil {
+				t.Fatalf("failed to apply header to %s: %+v", testfile, err)
+			}
+			compareFiles(t, testfile, "./testdata/"+fileName+".golden")
+		})
+	}
+}
+
+func TestDockerfileApplier_CheckHeader(t *testing.T){
+	files := []string{
+		// The non-golden files don't have a header present
+		"Dockerfile.nodirectives",
+		"Dockerfile.comments",
+		"Dockerfile.single-directive",
+		"Dockerfile.multiple-directives",
+
+		// The golden files should have the header present
+		"Dockerfile.nodirectives.golden",
+		"Dockerfile.comments.golden",
+		"Dockerfile.single-directive.golden",
+		"Dockerfile.multiple-directives.golden",
+	}
+
+	d := dockerfileApplier{}
+	tc := newTagContext(t)
+	defer func() { _ = tc.templateFiles.dTemplateFile.Close()}()
+	for _, f := range files {
+		fileName := f
+		t.Run(fileName, func(t *testing.T){
+			f, err := os.Open("./testdata/"+ fileName)
+			if err != nil {
+				t.Fatalf("failed to optn file %s: %+v", fileName, err)
+			}
+			defer func() { _ = f.Close() }()
+			found, err := d.CheckHeader(f, &tc)
+			if err != nil {
+				t.Fatalf("failed to check header: %+v", err)
+			}
+			expected := strings.HasSuffix(fileName, ".golden")
+			if found != expected {
+				t.Fail()
+			}
+		})
+	}
+}
+
+
+func newTagContext(t *testing.T) TagContext{
+	t.Helper()
+	templateFile, err := loadTemplate( "./testdata/templates/", "dockerfile.txt")
+	if err != nil {
+		t.Fatalf("failed to load dockerfile template")
+	}
+	return TagContext{
+		templateFiles: TemplateFiles{dTemplateFile: templateFile},
+		templatePath:   "./testdata/templates/",
+	}
+}
+
+func copyFile(t *testing.T, src, dst string) {
+	t.Helper()
+	input, err := ioutil.ReadFile(src)
+	if err != nil {
+		t.Fatalf("failed to read %s: %+v", src, err)
+	}
+	err = ioutil.WriteFile(dst, input, 0777)
+	if err != nil {
+		t.Fatalf("failed to write %s: %+v", dst, err)
+	}
+}
+
+func compareFiles(t *testing.T, a, b string) {
+	contentA, err := ioutil.ReadFile(a)
+	if err != nil {
+		t.Fatalf("failed to read file %s: %+v", a, err)
+	}
+	contentB, err := ioutil.ReadFile(b)
+	if err != nil {
+		t.Fatalf("failed to read golden file %s: %+v", b, err)
+	}
+	if !bytes.Equal(contentA, contentB) {
+		if _, err := exec.LookPath("git"); err == nil {
+			diff := exec.Command("git", "diff", "--no-index", a, b)
+			stdoutStderr, _ := diff.CombinedOutput()
+			t.Fatalf("%s\n", stdoutStderr)
+		} else {
+			t.Fatalf("content of %s did not match %s.\nContent A:\n%s\n\nContent B:\n%s\n", a, b, contentA, contentB)
+		}
+	}
+}

--- a/testdata/Dockerfile.comments
+++ b/testdata/Dockerfile.comments
@@ -1,0 +1,4 @@
+# this is not a directive = test
+# this is a comment
+FROM scratch
+LABEL foo=bar

--- a/testdata/Dockerfile.comments.golden
+++ b/testdata/Dockerfile.comments.golden
@@ -1,0 +1,19 @@
+#   Copyright <YYYY> <Organization Name>
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+
+# this is not a directive = test
+# this is a comment
+FROM scratch
+LABEL foo=bar

--- a/testdata/Dockerfile.multiple-directives
+++ b/testdata/Dockerfile.multiple-directives
@@ -1,0 +1,7 @@
+# directive=one
+# directive=two
+# directive=three
+# directive=four
+# some comment here
+FROM scratch
+LABEL foo=bar

--- a/testdata/Dockerfile.multiple-directives.golden
+++ b/testdata/Dockerfile.multiple-directives.golden
@@ -1,0 +1,24 @@
+# directive=one
+# directive=two
+# directive=three
+# directive=four
+
+
+#   Copyright <YYYY> <Organization Name>
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+
+# some comment here
+FROM scratch
+LABEL foo=bar

--- a/testdata/Dockerfile.nodirectives
+++ b/testdata/Dockerfile.nodirectives
@@ -1,0 +1,2 @@
+FROM scratch
+LABEL foo=bar

--- a/testdata/Dockerfile.nodirectives.golden
+++ b/testdata/Dockerfile.nodirectives.golden
@@ -1,0 +1,17 @@
+#   Copyright <YYYY> <Organization Name>
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+
+FROM scratch
+LABEL foo=bar

--- a/testdata/Dockerfile.single-directive
+++ b/testdata/Dockerfile.single-directive
@@ -1,0 +1,4 @@
+# syntax=docker/dockerfile:1.1.3-experimental
+# some comment here
+FROM scratch
+LABEL foo=bar

--- a/testdata/Dockerfile.single-directive.golden
+++ b/testdata/Dockerfile.single-directive.golden
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1.1.3-experimental
+
+
+#   Copyright <YYYY> <Organization Name>
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+
+# some comment here
+FROM scratch
+LABEL foo=bar

--- a/testdata/templates/dockerfile.txt
+++ b/testdata/templates/dockerfile.txt
@@ -1,0 +1,15 @@
+#   Copyright <YYYY> <Organization Name>
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+


### PR DESCRIPTION
fixes https://github.com/kunalkushwaha/ltag/issues/5 "Dockerfile support does not support directives"

Docker 1.12 and up supports parser directives in the
Dockerfile. Parser directives must be at the top of the
file to be valid.

This patch modified the DockerfileApplier to take parser
directives into account and (if found) puts the header
directly after the directives.

