### PR TITLE
Use regex for shebang detection in bash files

### DIFF
--- a/bash_test.go
+++ b/bash_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBashApplier_ApplyHeader(t *testing.T){
+	tc := newBashTagContext(t)
+	defer func() { _ = tc.templateFiles.dTemplateFile.Close()}()
+
+
+	tmpDir, err := ioutil.TempDir("", t.Name())
+	if err != nil {
+		t.Fatalf("failed to create temp directory")
+	}
+	defer func() { _ = os.RemoveAll(tmpDir)}()
+
+	files := []string{
+		"bash.simple",
+		"bash.comments",
+		"bash.shebang",
+		"bash.env.shebang",
+		"bash.sh.shebang",
+		"bash.make.shebang",
+	}
+
+	d := bashApplier{}
+	for _, f := range files {
+		fileName := f
+		t.Run(fileName, func(t *testing.T){
+			testfile := filepath.Join(tmpDir, fileName)
+			copyBashFile(t, "./testdata/"+fileName, testfile)
+
+			err = d.ApplyHeader(testfile, &tc)
+			if err != nil {
+				t.Fatalf("failed to apply header to %s: %+v", testfile, err)
+			}
+			compareBashFiles(t, testfile, "./testdata/"+fileName+".golden")
+		})
+	}
+}
+
+func TestBashFileApplier_CheckHeader(t *testing.T){
+	files := []string{
+		// The non-golden files don't have a header present
+		"bash.simple",
+		"bash.comments",
+		"bash.shebang",
+		"bash.env.shebang",
+		"bash.sh.shebang",
+		"bash.make.shebang",
+
+		// The golden files should have the header present
+		"bash.simple.golden",
+		"bash.comments.golden",
+		"bash.shebang.golden",
+		"bash.env.shebang.golden",
+		"bash.sh.shebang.golden",
+		"bash.make.shebang.golden",
+	}
+
+	d := bashApplier{}
+	tc := newBashTagContext(t)
+	defer func() { _ = tc.templateFiles.dTemplateFile.Close()}()
+	for _, f := range files {
+		fileName := f
+		t.Run(fileName, func(t *testing.T){
+			f, err := os.Open("./testdata/"+ fileName)
+			if err != nil {
+				t.Fatalf("failed to optn file %s: %+v", fileName, err)
+			}
+			defer func() { _ = f.Close() }()
+			found, err := d.CheckHeader(f, &tc)
+			if err != nil {
+				t.Fatalf("failed to check header: %+v", err)
+			}
+			expected := strings.HasSuffix(fileName, ".golden")
+			if found != expected {
+				t.Fail()
+			}
+		})
+	}
+}
+
+func newBashTagContext(t *testing.T) TagContext{
+	t.Helper()
+	templateFile, err := loadTemplate( "./testdata/templates/", "bash.txt")
+	if err != nil {
+		t.Fatalf("failed to load bash template")
+	}
+	return TagContext{
+		templateFiles: TemplateFiles{shTemplateFile: templateFile},
+		templatePath:   "./testdata/templates/",
+	}
+}
+
+func copyBashFile(t *testing.T, src, dst string) {
+	t.Helper()
+	input, err := ioutil.ReadFile(src)
+	if err != nil {
+		t.Fatalf("failed to read %s: %+v", src, err)
+	}
+	err = ioutil.WriteFile(dst, input, 0777)
+	if err != nil {
+		t.Fatalf("failed to write %s: %+v", dst, err)
+	}
+}
+
+func compareBashFiles(t *testing.T, a, b string) {
+	contentA, err := ioutil.ReadFile(a)
+	if err != nil {
+		t.Fatalf("failed to read file %s: %+v", a, err)
+	}
+	contentB, err := ioutil.ReadFile(b)
+	if err != nil {
+		t.Fatalf("failed to read golden file %s: %+v", b, err)
+	}
+	if !bytes.Equal(contentA, contentB) {
+		if _, err := exec.LookPath("git"); err == nil {
+			diff := exec.Command("git", "diff", "--no-index", a, b)
+			stdoutStderr, _ := diff.CombinedOutput()
+			t.Fatalf("%s\n", stdoutStderr)
+		} else {
+			t.Fatalf("content of %s did not match %s.\nContent A:\n%s\n\nContent B:\n%s\n", a, b, contentA, contentB)
+		}
+	}
+}

--- a/testdata/bash.comments
+++ b/testdata/bash.comments
@@ -1,0 +1,2 @@
+# this is comment
+echo "Hello!"

--- a/testdata/bash.comments.golden
+++ b/testdata/bash.comments.golden
@@ -1,0 +1,16 @@
+#   Copyright <YYYY> <Organization Name>
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# this is comment
+echo "Hello!"

--- a/testdata/bash.env.shebang
+++ b/testdata/bash.env.shebang
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+# this is a comment
+print "Hello!"

--- a/testdata/bash.env.shebang.golden
+++ b/testdata/bash.env.shebang.golden
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+#   Copyright <YYYY> <Organization Name>
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+
+# this is a comment
+print "Hello!"

--- a/testdata/bash.make.shebang
+++ b/testdata/bash.make.shebang
@@ -1,0 +1,3 @@
+#!/usr/bin/make -f
+# this is a comment
+echo "Hello!"

--- a/testdata/bash.make.shebang.golden
+++ b/testdata/bash.make.shebang.golden
@@ -1,0 +1,19 @@
+#!/usr/bin/make -f
+
+#   Copyright <YYYY> <Organization Name>
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+
+# this is a comment
+echo "Hello!"

--- a/testdata/bash.sh.shebang
+++ b/testdata/bash.sh.shebang
@@ -1,0 +1,3 @@
+#!/bin/sh
+# this is a comment
+echo "Hello!"

--- a/testdata/bash.sh.shebang.golden
+++ b/testdata/bash.sh.shebang.golden
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+#   Copyright <YYYY> <Organization Name>
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+
+# this is a comment
+echo "Hello!"

--- a/testdata/bash.shebang
+++ b/testdata/bash.shebang
@@ -1,0 +1,3 @@
+#!/bin/bash
+# this is a comment
+echo "Hello!"

--- a/testdata/bash.shebang.golden
+++ b/testdata/bash.shebang.golden
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+#   Copyright <YYYY> <Organization Name>
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+
+# this is a comment
+echo "Hello!"

--- a/testdata/bash.simple
+++ b/testdata/bash.simple
@@ -1,0 +1,1 @@
+echo "Hello!"

--- a/testdata/bash.simple.golden
+++ b/testdata/bash.simple.golden
@@ -1,0 +1,15 @@
+#   Copyright <YYYY> <Organization Name>
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+echo "Hello!"

--- a/testdata/templates/bash.txt
+++ b/testdata/templates/bash.txt
@@ -1,0 +1,14 @@
+#   Copyright <YYYY> <Organization Name>
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+


### PR DESCRIPTION
Signed-off-by: Guillaume Lours <guillaume.lours@docker.com>

I had some issues when generating the license header with executable files using shebang (other than `sh` and `bash`)

I propose to use a regex to detect shebang and manage executable files with `perl`, `python` , `make` ... as ltag does for `sh` and `bash`