### PR TITLE
fix symbolic link panic

### DIFF
--- a/main.go
+++ b/main.go
@@ -118,6 +118,10 @@ func (t *TagContext) tagFiles(path string, f os.FileInfo, err error) error {
 	var applier Applier
 	processed := false
 
+	if (f.Mode() & os.ModeSymlink) != 0 { // skip symlinks
+		return nil
+	}
+
 	if (f.Name() == ".git" || f.Name() == ".svn" || f.Name() == "..") && f.IsDir() {
 		return filepath.SkipDir
 	}


### PR DESCRIPTION
avoids panic when running into a symlink by ignoring the symlink needed for 
https://github.com/containerd/cri/blob/master/test/e2e

before:
```
ltag -t "../project/script/validate/template" --excludes "vendor" --check -v
panic: read test/e2e: is a directory

goroutine 1 [running]:
main.main()
	/home/mike/go/src/github.com/kunalkushwaha/ltag/main.go:99 +0xa95
```
after fix:
```
ltag -t "../project/script/validate/template" --excludes "vendor" --check -v
_output/containerd
```
See: https://golang.org/pkg/path/filepath/ "Walk does not follow symbolic links." possibly fixed in 1.14.3 https://github.com/golang/go/commit/7d27e87d35b4c8948a498711cb34c1f73917535b

Signed-off-by: Mike Brown <brownwm@us.ibm.com>

