### PR TITLE
 golang: support Go 1.17 compiler flags (e.g., `//go:build !windows`)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,22 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.13
+    - name: Set up Go 1.17
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.17
       id: go
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
-
-    - name: Get dependencies
-      run: |
-        go get -v -t -d ./...
-        if [ -f Gopkg.toml ]; then
-            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-            dep ensure
-        fi
     
     - name: Test
       run: go test ./...

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/kunalkushwaha/ltag
+
+go 1.17


### PR DESCRIPTION
Required for https://github.com/containerd/containerd/pull/5903

@kunalkushwaha Could you create a new release with this?
